### PR TITLE
Expanded by few matches and added tiny bit of logging

### DIFF
--- a/Moqstitute/Program.cs
+++ b/Moqstitute/Program.cs
@@ -71,8 +71,6 @@ namespace Moqstitute
                     Console.WriteLine($"Replacing Moq in: {fileName}");
                     File.WriteAllText(fileName, csFile);
                 }
-
-                Console.WriteLine($"Finished with: {fileName}");
             }
         }
     }

--- a/Moqstitute/config.txt
+++ b/Moqstitute/config.txt
@@ -30,5 +30,9 @@ using Ninject.MockingKernel.Moq;
 using Ninject.MockingKernel.NSubstitute;
 \.GetMock<(.+?)>\(\)
 .Get<(.+?)>()
-\.Object
-blank
+\.Object([\.,;)\s])
+$1
+\.Setup(Get)?\((\w+) => \2(\.?.+?)\)
+$3
+\.Returns\(\(\)\s=>\s
+.Returns(

--- a/Moqstitute/config.txt
+++ b/Moqstitute/config.txt
@@ -36,3 +36,5 @@ $1
 $3
 \.Returns\(\(\)\s=>\s
 .Returns(
+Mock.Of
+Substitute.For


### PR DESCRIPTION
I have added a few more regex-es, to try and match slightly different code bases, namely matches added for:

- .Object followed by: , . ) or ; - this was originally replacing partial words in i.e. using directives
- Added one more explicit match for only `.Setup`, because not always we have `.Get` in front of it
- Replaced `.Returns` with lambda to one without it
- Replaced `Mock.Of` with `Substitute.For`

There are still a few improvements to be made, but this will get everyone almost there :)

In the end, I know this is a one off tool, which is why I liked it, so decided to contribute few lines, feel free to ignore this PR :) 
